### PR TITLE
feat: add build scripts and configure Codeium MCP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+dist/
+.envrc

--- a/home/darwin.nix
+++ b/home/darwin.nix
@@ -39,6 +39,9 @@
     recursive = true;
     source = ./config/hammerspoon;
   };
+  home.file.".codeium/windsurf/mcp_config.json" = {
+    text = builtins.readFile (builtins.toPath "/Users/yoshimasauehara/ghq/github.com/yoshi12u/dotfiles/dist/mcp_config.json");
+  };
   programs.wezterm = {
     enable = true;
     extraConfig = builtins.readFile ./config/wezterm/wezterm.lua;

--- a/script/build.sh
+++ b/script/build.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Get target from command line argument, default to darwin
+TARGET="${1}"
+
+# Generate MCP config
+./script/generate-mcp-config.sh
+
+# Run home-manager switch with the specified flake target
+home-manager switch --flake ".#$TARGET" --impure
+
+echo "Build completed for target: $TARGET"

--- a/script/generate-mcp-config.sh
+++ b/script/generate-mcp-config.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Ensure dist directory exists
+mkdir -p dist
+
+# Generate MCP config file with secrets from environment variables
+cat >dist/mcp_config.json <<EOF
+{
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"
+      }
+    }
+  }
+}
+EOF
+
+echo "Generated MCP config in dist/mcp_config.json"
+


### PR DESCRIPTION
## Summary
- Add build.sh script for home-manager switch
- Add generate-mcp-config.sh for Codeium MCP configuration
- Update darwin.nix to include MCP config file
- Add .gitignore with dist/ and .envrc patterns

## Test plan
- Run ./script/build.sh to verify the script works correctly
- Verify MCP config is generated and properly linked in home configuration

🤖 Generated with [Claude Code](https://claude.ai/code)