### PR TITLE
Add devcontainer and setup script for Codex

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,8 @@
+{
+  "name": "codex-dev",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "features": {
+    "ghcr.io/devcontainers/features/nix:1": {}
+  },
+  "postCreateCommand": "./setup_codex.sh"
+}

--- a/README.md
+++ b/README.md
@@ -13,3 +13,14 @@ Personal dotfiles managed with Nix and Home Manager.
   - Zellij
   - Git
 
+
+## Codex Development Setup
+
+This repository includes a devcontainer definition for the Codex environment. To get started:
+
+```bash
+# Launch the devcontainer or run the setup script manually
+./setup_codex.sh
+```
+
+The script installs Nix if needed and applies the `x86_64-devcontainer` Home Manager configuration.

--- a/setup_codex.sh
+++ b/setup_codex.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v nix >/dev/null 2>&1; then
+  curl -L https://nixos.org/nix/install | sh -s -- --no-daemon
+  . "$HOME/.nix-profile/etc/profile.d/nix.sh"
+fi
+
+# Enable Nix flakes and use home-manager to apply the devcontainer configuration
+export NIX_CONFIG="experimental-features = nix-command flakes"
+
+nix run .#homeConfigurations.x86_64-devcontainer.activationPackage


### PR DESCRIPTION
## Summary
- add a devcontainer configuration with Nix support
- provide a `setup_codex.sh` script to install Nix and apply the devcontainer Home Manager config
- update README with Codex development instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68621e43326c8330bdd4067cd2c4b19a